### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Features
 - Series watch history
 - Captions removal (Requires a page reload on first disable)
-- Want more freautes? open a pull reuqest
+- Want more features? open a pull reuqest
 
 ## Attribution
 - <a href="https://www.flaticon.com/free-icons/popcorn" title="popcorn icons">Popcorn icons created by Freepik - Flaticon</a>


### PR DESCRIPTION
Fixed a typo in your README.

`freatues -> features`